### PR TITLE
Cleaning cache after build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN docker-php-ext-configure gd
 RUN docker-php-ext-install gd
 
 # Clear instalation cache
-RUN rm -rf /tmp/corpusopssteroids /var/cache/apk/* /var/lib/apt/lists/* && rm -rf /var/lib/apt/lists/*
+RUN rm -rf /var/lib/apt/lists/*
 
 # Enabling OPcache and JIT. Will be moved to php.ini
 # set recommended PHP.ini settings

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN docker-php-ext-configure gd
 RUN docker-php-ext-install gd
 
 # Clear instalation cache
-RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN rm -rf /tmp/corpusopssteroids /var/cache/apk/* /var/lib/apt/lists/* && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app/bimbalacom
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,9 @@ RUN docker-php-ext-install pdo_mysql bcmath mbstring zip exif pcntl xml
 RUN docker-php-ext-configure gd
 RUN docker-php-ext-install gd
 
+# Clear instalation cache
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app/bimbalacom
 
 COPY --from=builder /app /app/bimbalacom


### PR DESCRIPTION
## Description

Trying to clean the docker images of files we will not use after the initial install. This hopefully will help also in the future when we add more services to the container as well.

Before: ~ 885.61 MB
After: ~ 827.19 MB

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Just building the docker image.

