### PR TITLE
Setting timezone on the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,10 @@ RUN docker-php-ext-install pdo_mysql && \
 
 FROM php:8.0-fpm-alpine
 
+## Essential: Set the timezone
+RUN apk add --no-cache tzdata
+ENV TZ=Europe/Sofia
+
 RUN apk update && apk add \
     build-base \
     freetype-dev \


### PR DESCRIPTION
## Description

The change is made so we can check logs in the same timezone as us. Making debugging easier.  The reason it is on a different RUN is for compliance's sake. 


## Type of change
- [X] Enhancement (non-breaking change which improves an existing functionality)

## How Has This Been Tested?

Build and check the time.

