### PR TITLE
Fixed `docker-command`

### DIFF
--- a/docker-command
+++ b/docker-command
@@ -2,7 +2,7 @@
 # This is a convenience script for issuing commands to the site's docker environment
 # Example: ./docker-command php artisan migrate
 
-container_id=$(docker ps -q -f name=dcmp_public);
+container_id=$(docker ps -q -f name=dcmp-public);
 
 if [ ! "$container_id" ]; then
   echo "Docker Containers are not running. Use: 'docker-compose up -d public'"


### PR DESCRIPTION
## Description

Fixed finding the container's ID by its name in the docker compose context in the  `./docker-command` shell script.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Ran the command locally

# Checklist

Please delete the options that are not relevant.

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
