### PR TITLE
Enabling dynamic php modules + fixing GD for jpg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN apk add autoconf && pecl install -o -f redis \
 
 
 RUN docker-php-ext-install pdo_mysql bcmath mbstring zip exif pcntl xml zip
-RUN docker-php-ext-configure gd
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg
 RUN docker-php-ext-install gd
 
 # Clear instalation cache

--- a/php/php.ini
+++ b/php/php.ini
@@ -1,3 +1,4 @@
+# where to get conf file: https://github.com/php/php-src/blob/php-8.0.0/php.ini-production
 ; suppress displaying of all errors in production
 display_errors = Off
 display_startup_errors = Off

--- a/php/php.ini
+++ b/php/php.ini
@@ -39,3 +39,5 @@ opcache.use_cwd=1
 ; nescessary for file uploads
 upload_max_filesize = 32M
 post_max_size = 32M
+
+extension=php_gd.dll

--- a/php/php.ini
+++ b/php/php.ini
@@ -41,4 +41,17 @@ opcache.use_cwd=1
 upload_max_filesize = 32M
 post_max_size = 32M
 
+;;;;;;;;;;;;;;;;;;;;;;
+; Dynamic Extensions ;
+;;;;;;;;;;;;;;;;;;;;;;
+
+extension=curl
+extension=ftp
+extension=fileinfo
 extension=php_gd.dll
+extension=intl
+extension=mbstring
+extension=exif      ; Must be after mbstring as it depends on it
+extension=mysqli
+extension=openssl
+extension=pdo_mysql


### PR DESCRIPTION
## Description

**Edited: Read the whole tread for the full context.**

When trying to add a new blog post, we have the error below. I found a fix that worked locally, but I'm not sure if it is the way to do it.  That is why I'm creating the PR:

* Is it a good way of doing it? - I saw people rewriting how it is installed in the Dockerfile
* Do we need to add it to the SaaS docker file?
* Do you know if we need to enable more extensions like this one?

Error:
`[2023-06-28 13:09:49] local.ERROR: Call to undefined function Intervention\Image\Gd\imagecreatefromjpeg() {"userId":2,"exception":"[object] (Error(code: 0): Call to undefined function Intervention\\Image\\Gd\\imagecreatefromjpeg() at /app/bimbalacom/vendor/intervention/image/src/Intervention/Image/Gd/Decoder.php:38)
`

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- [X] Locally



