### PR TITLE
Setting a static UID and GID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM php:8.0-cli-alpine as builder
 
 ARG APP_ENV="production"
 
+# Setting UID/GID to 1000:1000
+RUN sed -i 's/^root:x:0:0:/root:x:1000:1000:/' /etc/passwd
+
+
 # Everything is at one place
 # Commenting out for future use.
 # ENV PHP_INI_DIR /usr/local/etc/php


### PR DESCRIPTION
## Description

The idea behind this change is that it will help out the image uploader.

If your container does not have a static UID/GID, then one must extract this information from the running container before they can assign correct file permissions on the host machine. It is best that you use a single static UID/GID for all of your containers that never changes.

P.S. - this change may break the container as we know it. It is primarily a hacky fix to our problem. A good workaround Is to add a user who will receive the UID/GID permissions and have write permissions to our projects, but it is not a minor change and will hopefully be done soon in the future.


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Locally
