### PR TITLE
Removed the `/register` route from the sitemap

### DIFF
--- a/app/Console/Commands/GenerateSitemap.php
+++ b/app/Console/Commands/GenerateSitemap.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use Illuminate\Console\Command;
 use Psr\Http\Message\UriInterface;
 use Spatie\Sitemap\SitemapGenerator;
+use function in_array;
 
 class GenerateSitemap extends Command
 {
@@ -35,8 +36,12 @@ class GenerateSitemap extends Command
                 // All pages will be crawled, except the contact page.
                 // Links present on the contact page won't be added to the
                 // sitemap unless they are present on a crawlable page.
+                $blackList = [
+                    '/discord',
+                    '/register'
+                ];
 
-                return strpos($url->getPath(), '/discord') === false;
+                return !in_array($url->getPath(), $blackList);
             })
             ->writeToFile(public_path('sitemap.xml'));
     }


### PR DESCRIPTION
## Description
Removed the `register` route from the sitemap

Fixes https://search.google.com/search-console/index/drilldown?resource_id=https%3A%2F%2Fbimbala.com%2F&item_key=CAMYCyAC

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Hasn't been tested.

# Checklist

Please delete the options that are not relevant.

- [X] My code follows the style guidelines of this project
- X ] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings